### PR TITLE
typo

### DIFF
--- a/cholesky/benchmark.ini
+++ b/cholesky/benchmark.ini
@@ -7,7 +7,7 @@ Data = data-medium
 [ Test ]
 Exe = cholesky.i386
 Args = -p$NTHREADS
-Stdin = tk14.0
+Stdin = tk14.O
 Data = data-test
 
 [ Small ]


### PR DESCRIPTION
There is only `tk14.O` instead of `tk14.0` in `data-test` folder. I guess it may be a typo in `benchmark.ini`.